### PR TITLE
Fix LogNormalRanged returning wrong distribution

### DIFF
--- a/Assets/Scripts/Rand.cs
+++ b/Assets/Scripts/Rand.cs
@@ -130,7 +130,7 @@ public static class Rand
         MathF.Exp(Gaussian() * stdDev + mean);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static float LogNormalRanged(float mean, float stdDev) => mean + LogNormal(stdDev);
+    public static float LogNormalRanged(float mean, float stdDev) => LogNormal(mean, stdDev);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static float Cauchy(float x0 = 0f, float gamma = 1f)


### PR DESCRIPTION
## Summary
- correct LogNormalRanged to use mean argument

## Testing
- `dotnet test` *(fails: `dotnet` command not found)*